### PR TITLE
LIBFCREPO-743. Get the described resources classes.

### DIFF
--- a/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -141,8 +141,8 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpPatch request = patchObjMethod(protectedResource.replace(serverAddress, ""));
         setAuth(request, "fedoraAdmin");
         request.setHeader("Content-type", "application/sparql-update");
-        request.setEntity(new StringEntity(
-                "INSERT { <> <" + WEBAC_ACCESS_CONTROL_VALUE + "> <" + aclResource + "> . } WHERE {}"));
+        final String sparql = "INSERT { <> <" + WEBAC_ACCESS_CONTROL_VALUE + "> <" + aclResource + "> . } WHERE {}";
+        request.setEntity(new StringEntity(sparql));
         assertEquals(HttpStatus.SC_NO_CONTENT, getStatus(request));
     }
 
@@ -769,5 +769,14 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_NOT_FOUND, getStatus(getReq));
     }
 
-
+    @Test
+    public void testAccessToBinaryByClass() throws IOException {
+        final String binaryPath = "/rest/binary";
+        final String binary = ingestDatastream(binaryPath, "foo");
+        final String acl = ingestAcl("fedoraAdmin", "/acls/17/acl.ttl", "/acls/17/authorization.ttl");
+        linkToAcl(binary + "/fcr:metadata", acl);
+        final HttpGet getReq1 = getObjMethod(binaryPath);
+        setAuth(getReq1, "fedoraUser");
+        assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(getReq1));
+    }
 }

--- a/src/test/resources/acls/17/acl.ttl
+++ b/src/test/resources/acls/17/acl.ttl
@@ -1,0 +1,3 @@
+@prefix webac: <http://fedora.info/definitions/v4/webac#> .
+
+<> a webac:Acl .

--- a/src/test/resources/acls/17/authorization.ttl
+++ b/src/test/resources/acls/17/authorization.ttl
@@ -1,0 +1,8 @@
+@prefix acl: <http://www.w3.org/ns/auth/acl#> .
+@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<> a acl:Authorization ;
+   acl:agent foaf:Agent ;
+   acl:mode acl:Read ;
+   acl:accessToClass foaf:Document .


### PR DESCRIPTION
If a resource is a NonRDFSourceDescription, use the described resource when getting the list of RDF types.

https://issues.umd.edu/browse/LIBFCREPO-743